### PR TITLE
Add handling for dictionary to anyDictionaryType decl marshal code

### DIFF
--- a/declarations/marshal.go
+++ b/declarations/marshal.go
@@ -55,6 +55,8 @@ func anyDictionaryType(key *schema.PayloadKey) jen.Code {
 		return jen.Any()
 	case schema.PayloadKeyTypeString:
 		return jen.String()
+	case schema.PayloadKeyTypeDictionary:
+		return jen.Dict{}
 	default:
 		panic(fmt.Errorf("ANY <dictionary>: unknown value type: %s", key.Type))
 	}


### PR DESCRIPTION
This fixes a panic when running declgen on any commit newer than macOS 14.5 in the repo:

```
./declgen -repo "https://github.com/apple/device-management.git" -commit 85fae8ac896578447f8fcb07ff6c976128133a9c
panic: ANY <dictionary>: unknown value type: <dictionary>

goroutine 1 [running]:
github.com/korylprince/go-adm/declarations.anyDictionaryType(0x1032af2e0?)
        /Users/nate/code/go-adm/declarations/marshal.go:59 +0x2fc
github.com/korylprince/go-adm/declarations.(*Encoder).schemaType(0x14000244d20, 0x14000527b00)
        /Users/nate/code/go-adm/declarations/marshal.go:90 +0x48c
github.com/korylprince/go-adm/declarations.(*Encoder).renderSchema.func1({0x14000780198?, 0x1400069ea00?}, {0x1400077ebe8, 0x1, 0x102eda2c0?})
        /Users/nate/code/go-adm/declarations/marshal.go:180 +0x6b8
github.com/korylprince/go-adm/declarations.(*Encoder).renderSchema(0x14000244d20, 0x1400069ea00)
        /Users/nate/code/go-adm/declarations/marshal.go:223 +0x190
github.com/korylprince/go-adm/declarations.(*Encoder).Encode(0x14000244d20, {0x14000456600, 0x1b, 0x3?})
        /Users/nate/code/go-adm/declarations/marshal.go:296 +0xec
github.com/korylprince/go-adm/declarations.GenerateFromGit({0x16d3ff748, 0x2e}, {0x16d3ff77f?, 0x0?}, {0x102dc54b1, 0x18}, {0x0, 0x0, 0x0}, {0x102e61558, ...})
        /Users/nate/code/go-adm/declarations/marshal.go:362 +0xa44
main.checkFlags()
        /Users/nate/code/go-adm/cmd/declgen/main.go:53 +0x20c
main.main()
        /Users/nate/code/go-adm/cmd/declgen/main.go:61 +0x1c
```