### PR TITLE
feat(structgen): support multiple -path arguments for git repo mode

### DIFF
--- a/cmd/structgen/main.go
+++ b/cmd/structgen/main.go
@@ -12,6 +12,17 @@ import (
 	"github.com/korylprince/go-adm/utils/replace"
 )
 
+type paths []string
+
+func (p *paths) String() string {
+	return strings.Join(*p, ",")
+}
+
+func (p *paths) Set(v string) error {
+	*p = append(*p, v)
+	return nil
+}
+
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags] [yamlFile [yamlFile [...]]]\n\nGenerate Go structs from YAML schema files.\nEither provide local YAML files as arguments or use -repo/-commit/-path to fetch from a git repository.\n\nFlags:\n", os.Args[0])
@@ -25,8 +36,9 @@ func main() {
 		flReqDef = flag.Bool("reqdef", false, "generate required and default struct tags")
 		flRepo   = flag.String("repo", "", "git repository URL")
 		flCommit = flag.String("commit", "", "git commit")
-		flPath   = flag.String("path", "", "path within git repository to YAML schema directory")
+		flPaths  paths
 	)
+	flag.Var(&flPaths, "path", "path within git repository to YAML schema directory (can be specified multiple times)")
 	flag.Parse()
 
 	var err error
@@ -61,10 +73,10 @@ func main() {
 		if *flCommit == "" {
 			log.Fatal("-commit must be specified when using -repo")
 		}
-		if *flPath == "" {
+		if len(flPaths) == 0 {
 			log.Fatal("-path must be specified when using -repo")
 		}
-		err = structgen.GenerateFromGit(*flRepo, *flCommit, *flPath, *flPkg, repl, tags, f, encOpts...)
+		err = structgen.GenerateFromGit(*flRepo, *flCommit, flPaths, *flPkg, repl, tags, f, encOpts...)
 	} else {
 		if len(flag.Args()) < 1 {
 			fmt.Fprintf(flag.CommandLine.Output(), "no yamlFile names provided\n")

--- a/generator/structgen/marshal.go
+++ b/generator/structgen/marshal.go
@@ -94,7 +94,7 @@ func GenerateFromFiles(fileNames []string, pkg string, reps replace.Replacements
 	return nil
 }
 
-func GenerateFromGit(repoURL, commit, path, pkg string, reps replace.Replacements, tags []string, out io.Writer, opts ...EncodeOption) error {
+func GenerateFromGit(repoURL, commit string, paths []string, pkg string, reps replace.Replacements, tags []string, out io.Writer, opts ...EncodeOption) error {
 	repo, err := git.New(repoURL, commit)
 	if err != nil {
 		return fmt.Errorf("could not check out repository: %w", err)
@@ -106,30 +106,32 @@ func GenerateFromGit(repoURL, commit, path, pkg string, reps replace.Replacement
 	}
 
 	var schemas []*schema.Schema
-	if err = util.Walk(repo, path, func(filePath string, info fs.FileInfo, _ error) error {
-		if !strings.HasSuffix(info.Name(), ".yaml") {
+	for _, path := range paths {
+		if err = util.Walk(repo, path, func(filePath string, info fs.FileInfo, _ error) error {
+			if !strings.HasSuffix(info.Name(), ".yaml") {
+				return nil
+			}
+
+			buf, err := util.ReadFile(repo, filePath)
+			if err != nil {
+				return fmt.Errorf("could not read %s: %w", filePath, err)
+			}
+
+			s, err := schema.New(buf)
+			if err != nil {
+				return fmt.Errorf("could not parse %s: %w", filePath, err)
+			}
+			schemas = append(schemas, s)
+
 			return nil
+		}); err != nil {
+			return err
 		}
-
-		buf, err := util.ReadFile(repo, filePath)
-		if err != nil {
-			return fmt.Errorf("could not read %s: %w", filePath, err)
-		}
-
-		s, err := schema.New(buf)
-		if err != nil {
-			return fmt.Errorf("could not parse %s: %w", filePath, err)
-		}
-		schemas = append(schemas, s)
-
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	f := jen.NewFile(pkg)
 	f.HeaderComment("DO NOT EDIT")
-	f.HeaderComment(fmt.Sprintf("generated from %s:%s/%s", repoURL, hash, path))
+	f.HeaderComment(fmt.Sprintf("generated from %s:%s/%s", repoURL, hash, strings.Join(paths, ",")))
 
 	file := schema.NewFile(schemas)
 	opts = append([]EncodeOption{WithReplacements(reps), WithSchemaEncoderOption(schema.WithTags(tags))}, opts...)


### PR DESCRIPTION
Replace the single `-path` flag with a repeatable flag, allowing multiple paths within a git repository to be walked and combined into a single generated output file. Update GenerateFromGit signature accordingly.

Assisted-by: OpenCode:big-pickle